### PR TITLE
Add Mutable-Content field for iOS usage

### DIFF
--- a/src/main/kotlin/com/github/tokou/firebasepush/MainView.kt
+++ b/src/main/kotlin/com/github/tokou/firebasepush/MainView.kt
@@ -94,6 +94,7 @@ class MainView : View("Firebase Push") {
                         field("Body") {
                             textfield(model.body)
                         }
+                        checkbox("Mutable-Content", model.mutableContent)
                         checkbox("Sound", model.sound)
                     }
                     tableview<KeyValueViewModel>(model.values) {

--- a/src/main/kotlin/com/github/tokou/firebasepush/models.kt
+++ b/src/main/kotlin/com/github/tokou/firebasepush/models.kt
@@ -5,11 +5,13 @@ import tornadofx.*
 data class Payload(
     private val registrationIds: List<String>,
     private val notification: Notification?,
+    private val mutableContent: Boolean?,
     private val data: Data?
 ) : JsonModel {
     override fun toJSON(json: JsonBuilder) { with(json) {
         add("registration_ids", registrationIds)
         add("notification", notification)
+        add("mutable_content", mutableContent)
         add("data", data)
     } }
 }

--- a/src/main/kotlin/com/github/tokou/firebasepush/viewmodels.kt
+++ b/src/main/kotlin/com/github/tokou/firebasepush/viewmodels.kt
@@ -29,6 +29,7 @@ class PayloadViewModel : ItemViewModel<Payload>() {
     val body = SimpleStringProperty()
     val notification = SimpleBooleanProperty()
     val sound = SimpleBooleanProperty()
+    val mutableContent = SimpleBooleanProperty()
     val data = SimpleBooleanProperty()
     val values = SimpleListProperty<KeyValueViewModel>(FXCollections.observableArrayList())
     val selected = SimpleObjectProperty<KeyValueViewModel>(KeyValueViewModel("", ""))
@@ -38,7 +39,7 @@ class PayloadViewModel : ItemViewModel<Payload>() {
         val payloadNotification = if (notification.value) Notification(title.get(), body.get(), soundValue) else null
         val payloadData = if (data.value) Data(convertValues()) else null
         val registrationIds = tokens.get() ?: emptyList<String>()
-        item = Payload(registrationIds, payloadNotification, payloadData)
+        item = Payload(registrationIds, payloadNotification, mutableContent.value, payloadData)
     }
 
     private fun convertValues() = values.map { it.key to it.value }.toMap()


### PR DESCRIPTION
iOS needs to be able to set this field when you want to use a
Notification Service Extension to process the notification before
presenting it to the user